### PR TITLE
Add export to StoryState class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export class Store {
   }
 }
 
-class StoryState extends React.Component {
+export class StoryState extends React.Component {
   static propTypes = {
     channel: T.object.isRequired,
     store: T.object.isRequired,


### PR DESCRIPTION
I am using this storybook-state plugin along with another plugin called info. Info allows me to view a props table of components. It auto picks up StoryState and lists it in the table without any props underneath. I would like to remove it from the info section of storybook. The only way for me to do that would be to add it to the variable propTablesExclude. propTablesExclude takes in an array of components. There is no way to reference the class without having "export" on the StoryState class. 