### PR TITLE
Differentiate between legacy and new typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,5 +20,8 @@ export type Store<T> = {
   reset(): void;
 };
 
-export type StorybookStateCallback<T> = (store: Store<T>) => Renderable | Renderable[];
-export function withState<T extends {}>(state: T, callback?: StorybookStateCallback<T>): any // RenderFunction;
+export type LegacyStorybookStateCallback<T> = (store: Store<T>) => Renderable | Renderable[];
+export function withState<T extends {}>(state: T, callback: LegacyStorybookStateCallback<T>): any // RenderFunction;
+
+export type StorybookStateCallback<T> = (context: {store: Store<T>}) => Renderable | Renderable[];
+export function withState<T extends {}>(state: T): (callback: StorybookStateCallback<T>) => any


### PR DESCRIPTION
I'm not sure if this is related to https://github.com/dump247/storybook-state/issues/8 or not.
I just added multiple typings for withState which show the multiple ways in which withState can be called. It fixed part of my issues.
Please review @dump247 @Cryrivers @thupi