### PR TITLE
fix: remove enzyme from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
-    "enzyme-adapter-react-16": "^1.6.0",
     "react": "^16.6.0",
     "react-json-view": "^1.13.3"
   },


### PR DESCRIPTION
It's a dev dependency, and causes peer dependency warnings in projects depending on `storybook-state`